### PR TITLE
feat: add GitHub Actions workflow to fix truncated articles

### DIFF
--- a/.github/workflows/fix-articles.yml
+++ b/.github/workflows/fix-articles.yml
@@ -1,0 +1,115 @@
+name: Fix Truncated Articles
+
+on:
+  # Manual trigger only
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Only validate, do not fix'
+        required: false
+        default: 'false'
+        type: boolean
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  fix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Restore previous build from cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            public/
+            data/
+          key: cmmcwatch-build-${{ github.run_number }}
+          restore-keys: |
+            cmmcwatch-build-
+
+      - name: Validate articles
+        run: |
+          cd scripts
+          echo "=== Checking for truncated articles ==="
+          python editorial_generator.py --validate
+
+      - name: Fix truncated articles
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        env:
+          GOOGLE_AI_API_KEY: ${{ secrets.GOOGLE_AI_API_KEY }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: |
+          cd scripts
+          echo "=== Fixing truncated articles ==="
+          python editorial_generator.py --fix
+          echo ""
+          echo "=== Validating after fix ==="
+          python editorial_generator.py --validate
+
+      - name: Regenerate articles index
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        run: |
+          cd scripts
+          python editorial_generator.py --regenerate-index
+
+      - name: Update cache with fixed articles
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        uses: actions/cache@v4
+        with:
+          path: |
+            public/
+            data/
+          key: cmmcwatch-build-${{ github.run_number }}
+
+      - name: Add CNAME for custom domain
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        run: echo "cmmcwatch.com" > public/CNAME
+
+      - name: Setup Pages
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './public'
+
+  deploy:
+    if: ${{ github.event.inputs.dry_run != 'true' }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    needs: fix
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Adds fix-articles.yml workflow that can be manually triggered to:
- Restore articles from the GitHub Actions cache
- Run --validate to check for truncated articles
- Run --fix to regenerate content for incomplete articles
- Redeploy to GitHub Pages

Options:
- dry_run: Only validate without fixing (for checking status)

Usage: Go to Actions > "Fix Truncated Articles" > Run workflow